### PR TITLE
Limit voters to 1000 in addVoters and insertRoot functions

### DIFF
--- a/contracts/ElectAnon.sol
+++ b/contracts/ElectAnon.sol
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "./SemaphoreOpt.sol";
 import {TidemanLib as TallyLib} from "./libs/tally/TidemanLib.sol";
@@ -157,6 +156,7 @@ contract ElectAnon is SemaphoreOpt {
         atState(States.Register)
         onlyOwner
     {
+        require(getLeavesNum() + _identityCommitments.length <= 1000, "Total number of voters cannot exceed 1000");
         insertLeaves(_identityCommitments, _root);
         emit VoterIdCommitsAdded(msg.sender, _identityCommitments, _root);
     }

--- a/contracts/assisted/ElectAnonAst.sol
+++ b/contracts/assisted/ElectAnonAst.sol
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "./SemaphoreAst.sol";
 import {BordaCountLib} from "../libs/tally/BordaCountLib.sol";
@@ -139,6 +138,7 @@ contract ElectAnonAst is SemaphoreAst {
         atState(States.Register)
         onlyOwner
     {
+        require(getLeavesNum() + _num <= 1000, "Total number of voters cannot exceed 1000");
         insertRoot(_root, _num);
     }
 

--- a/contracts/assisted/SemaphoreAst.sol
+++ b/contracts/assisted/SemaphoreAst.sol
@@ -82,6 +82,7 @@ contract SemaphoreAst is Verifier, Ownable {
     }
 
     function insertRoot(uint256 _root, uint256 _num) internal {
+        require(leavesNum + _num <= 1000, "Total number of voters cannot exceed 1000");
         leavesNum = _num;
         root = _root;
     }

--- a/test/electanon.js
+++ b/test/electanon.js
@@ -357,6 +357,25 @@ contract("ElectAnon", (accounts) => {
       web3.utils.toBN(this.contract.address).toString(16)
     );
   });
+
+  it("should not allow adding more than 1000 voters", async () => {
+    let idCommits = [];
+    for (let i = 0; i < 1001; i++) {
+      let identity = genIdentity();
+      let identityCommitment = genIdentityCommitment(identity);
+      idCommits.push(identityCommitment.toString());
+    }
+    let level = await this.contract.getTreeLevel();
+    let tree = await genTree(level, idCommits);
+    let root = await tree.root();
+    try {
+      await this.contract.addVoters(idCommits, root, {
+        from: this.owner,
+      });
+    } catch (e) {
+      expect(e.message.endsWith("Total number of voters cannot exceed 1000"));
+    }
+  });
 });
 contract("ElectAnon commit", (accounts) => {
   before(async () => {


### PR DESCRIPTION
Add checks to ensure the total number of voters does not exceed 1000.

* **contracts/assisted/ElectAnonAst.sol**
  - Add a check in the `addVoters` function to ensure the total number of voters does not exceed 1000 before inserting new voters.
* **contracts/ElectAnon.sol**
  - Add a check in the `addVoters` function to ensure the total number of voters does not exceed 1000 before inserting new voters.
* **contracts/assisted/SemaphoreAst.sol**
  - Add a check in the `insertRoot` function to ensure the total number of voters does not exceed 1000 before inserting the new root.
* **test/electanon.js**
  - Add a test to check that the `addVoters` function in `ElectAnon` contract does not allow adding more than 1000 voters.

